### PR TITLE
Depend on dask-ms > 0.2.5 and pytest-flake8 >= 1.0.6

### DIFF
--- a/.travis/python35.docker
+++ b/.travis/python35.docker
@@ -2,7 +2,7 @@ FROM kernsuite/base:5
 
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip git python3-casacore
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip git
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code

--- a/.travis/python36.docker
+++ b/.travis/python36.docker
@@ -2,7 +2,7 @@ FROM kernsuite/base:5
 
 # Install base requirements
 RUN DEBIAN_FRONTEND=noninteractive apt update -y
-RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip git python3-casacore
+RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip git
 RUN pip3 install --upgrade pip setuptools
 ADD . /code
 WORKDIR /code

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.1.8 (YYYY-MM-DD)
+------------------
+* Work around broken pytest-flake8 (:pr:`69`)
+
 0.1.7 (2020-01-06)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.1.8 (YYYY-MM-DD)
 ------------------
 * Upgrade to dask-ms 0.2.5 (:pr:`69`)
-* Work around broken pytest-flake8 (:pr:`69`)
+* Upgrade to pytest-flake8 1.0.6 (:pr:`69`)
 
 0.1.7 (2020-01-06)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.8 (YYYY-MM-DD)
 ------------------
+* Upgrade to dask-ms 0.2.5 (:pr:`69`)
 * Work around broken pytest-flake8 (:pr:`69`)
 
 0.1.7 (2020-01-06)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ requirements = [
     'zarr >= 2.3.1'
 ]
 
-extras_require = {'testing': ['pytest', 'pytest-flake8', 'requests']}
+# TODO(sjperkins)
+# Modify flake8 < 3.8.0 once
+# https://github.com/tholo/pytest-flake8/issues/66 is fixed
+extras_require = {'testing': ['pytest', 'pytest-flake8',
+                              'requests', 'flake8 < 3.8.0']}
 
 setup(
     author="Simon Perkins",

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,7 @@ requirements = [
     'zarr >= 2.3.1'
 ]
 
-# TODO(sjperkins)
-# Modify flake8 < 3.8.0 once
-# https://github.com/tholo/pytest-flake8/issues/66 is fixed
-extras_require = {'testing': ['pytest', 'pytest-flake8',
-                              'requests', 'flake8 < 3.8.0']}
+extras_require = {'testing': ['pytest', 'pytest-flake8 >= 1.0.6', 'requests']}
 
 setup(
     author="Simon Perkins",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'numba >= 0.43.0',
     'scipy >= 1.2.0',
     'threadpoolctl >= 1.0.0',
-    'dask-ms >= 0.2.3',
+    'dask-ms >= 0.2.5',
     'zarr >= 2.3.1'
 ]
 


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API


<details>
<summary> Howto run test cases and lint the code base </summary>

```bash
$ py.test --flake8 -v -s tricolour
```

If you encounter flake8 failures, a quick way to correct
this is to run `autopep8` and `flake8` again.

```bash
$ pip install -U autopep8
$ autopep8 -r -i tricolour
$ flake8 tricolour
```

</details>


<details>
<summary> Howto build the documentation </summary>

To build the docs locally:

```bash
$ pip install -r requirements.readthedocs.txt
$ cd docs
$ READTHEDOCS=True make html
```

</details>
