### PR TITLE
Fix path logic in mask glob

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "tricolour"
-version = "0.2.0"
+version = "0.2.1"
 description = "Science Data Processing flagging code, wrapped in dask"
 authors = [{name = "Simon Perkins"}]
 license = "GPLv2"

--- a/tricolour/mask.py
+++ b/tricolour/mask.py
@@ -19,7 +19,7 @@ try:
 except ModuleNotFoundError:
     import importlib
     from os.path import join as pjoin
-    _DEFAULT_PATHS = pjoin(importlib.resources.files('tricolour'), 'data')
+    _DEFAULT_PATHS = config.paths + [pjoin(importlib.resources.files('tricolour'), 'data')]
 
 def dilate_mask(mask_chans, mask_flags, dilate):
     """


### PR DESCRIPTION
Fix a bug introduced in importlib usage. Currently the list of paths to detect masks is by default a string instead of a list.
