### PR TITLE
Add acceptance-test workflow (comment + dispatch triggers)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,143 @@
+name: Acceptance Test
+
+# Runs the (slow) end-to-end acceptance suite. It is intentionally kept out of
+# the standard CI matrix.
+#
+# It runs:
+#   * on demand when an authorized user comments `/test-acceptance` on a PR
+#   * manually via the Actions UI (workflow_dispatch), optionally against a PR
+#
+# NOTE: a `push: branches: [master]` trigger is intended to be added once the
+# acceptance test code (the `acceptance` marker, tests/test_acceptance.py and
+# tests/custom.yaml) has landed on master. Both triggers below check out the
+# *PR head*, so they run that branch's test code, not master's.
+on:
+  issue_comment:
+    types: [ created ]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to run against (optional; defaults to the dispatched ref)"
+        required: false
+        type: string
+
+# Required to report status back and react to the triggering comment.
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
+# Avoid piling up runs for the same PR / branch.
+concurrency:
+  group: acceptance-${{ github.event_name == 'issue_comment' && github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance:
+    name: Acceptance Test
+    # Run on `/test-acceptance` comments on a PR, or a manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/test-acceptance'))
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check authorization
+        if: github.event_name == 'issue_comment'
+        run: |
+          assoc="${{ github.event.comment.author_association }}"
+          case "$assoc" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Authorized to run acceptance tests ($assoc)" ;;
+            *)
+              echo "::error::@${{ github.event.comment.user.login }} ($assoc) is not authorized to run acceptance tests"
+              exit 1 ;;
+          esac
+
+      - name: Acknowledge command
+        if: github.event_name == 'issue_comment'
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes
+
+      - name: Resolve checkout ref
+        id: ref
+        run: |
+          pr=""
+          case "${{ github.event_name }}" in
+            issue_comment)
+              pr="${{ github.event.issue.number }}" ;;
+            workflow_dispatch)
+              pr="${{ github.event.inputs.pr }}" ;;
+          esac
+
+          if [ -n "$pr" ]; then
+            sha=$(gh pr view "$pr" --repo "${{ github.repository }}" \
+              --json headRefOid -q .headRefOid)
+          else
+            sha="${{ github.sha }}"
+          fi
+
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Acceptance tests will run against $sha${pr:+ (PR #$pr)}"
+
+      - name: Mark commit status pending
+        run: |
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.ref.outputs.sha }}" \
+            -f state=pending \
+            -f context="acceptance" \
+            -f description="Acceptance tests running" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: |
+          uv sync --group test --extra meerkat --extra msv2 --extra zarr
+          # Acceptance-only dependencies, not part of the project deps.
+          # python-casacore ships manylinux wheels that bundle casacore.
+          uv pip install gdown python-casacore
+
+      - name: Run acceptance tests
+        run: uv run pytest -v -s -m acceptance
+
+      - name: Report result
+        if: always()
+        run: |
+          state=success
+          [ "${{ job.status }}" = "success" ] || state=failure
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.ref.outputs.sha }}" \
+            -f state="$state" \
+            -f context="acceptance" \
+            -f description="Acceptance tests $state" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          pr="${{ steps.ref.outputs.pr }}"
+          if [ -n "$pr" ]; then
+            run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            if [ "$state" = "success" ]; then
+              body="✅ Acceptance tests passed — [logs]($run_url)"
+            else
+              body="❌ Acceptance tests failed — [logs]($run_url)"
+            fi
+            gh api -X POST \
+              "repos/${{ github.repository }}/issues/$pr/comments" \
+              -f body="$body"
+          fi


### PR DESCRIPTION
Adds `.github/workflows/acceptance.yml` to `master` so the on-demand acceptance-test triggers become available.

### Why a separate, minimal PR against `master`
`issue_comment` and `workflow_dispatch` workflows only run from the version of the file on the **default branch**. The new acceptance workflow currently lives only on `reconfigure-ci` (PR #104), so commenting `/test-acceptance` there does nothing. Landing just the workflow file on `master` registers the triggers without dragging in the rest of the in-progress CI rework.

### Triggers
- `/test-acceptance` comment on a PR (gated to `OWNER`/`MEMBER`/`COLLABORATOR`)
- manual `workflow_dispatch`, with an optional `pr` input

Both triggers **check out the PR head**, so they run that branch's test code (the `acceptance` marker, `tests/test_acceptance.py`, `tests/custom.yaml`) — not `master`'s. This is what lets us exercise PR #104 before its code is on `master`.

### Deliberately omitted
The `push: branches: [master]` trigger is **not** included here — it would fire on this merge commit and run against `master`, which doesn't yet have the acceptance test code, producing a spurious failure. It should be added together with the test-code landing.

### How to test after merge
```
gh workflow run acceptance.yml --repo ratt-ru/tricolour --ref reconfigure-ci -f pr=104
```
or comment `/test-acceptance` on PR #104. Results are reported as an `acceptance` commit status and a comment on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)